### PR TITLE
CTOOLS-22: Set default poetry request timeout to 120

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,7 @@ RUN --mount=type=ssh \
 COPY generate/ /usr/src/generate
 COPY ./justfile /usr/src/
 COPY test_sdk /usr/src/test_sdk
+
+# sometimes poetry publish fails due to connection timeouts
+# default is 15 secs, I've increased to 120 to mitigate.
+ENV POETRY_REQUESTS_TIMEOUT=120


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

