### PR TITLE
wip: fixed ownership when client passes connector

### DIFF
--- a/generate/templates/extensions/api_client_factory.mustache
+++ b/generate/templates/extensions/api_client_factory.mustache
@@ -184,6 +184,7 @@ class ApiClientFactory:
         A list of aiohttp TraceConfigs, used to set up request tracing.
         by default None
         """
+        owner = True
         api_config = get_api_configuration(config_loaders=config_loaders)
         api_client_config = api_config.build_api_client_config(
             tcp_keep_alive=tcp_keep_alive,
@@ -197,6 +198,7 @@ class ApiClientFactory:
         try:
             if client_session is not None:
                 connector = client_session.connector
+                owner = False
                 # by default take explicitly passed trace_config param
                 # otherwise copy from session.
                 trace_configs = trace_configs or client_session.trace_configs
@@ -209,7 +211,8 @@ class ApiClientFactory:
             rc.pool_manager = ClientSession(
                 connector=connector,
                 trust_env=True,
-                trace_configs=trace_configs
+                trace_configs=trace_configs,
+                connector_owner=owner
             )
         except AttributeError:
             logger.exception("client_session must be an aiohttp.ClientSession"

--- a/generate/templates/extensions/api_client_factory.mustache
+++ b/generate/templates/extensions/api_client_factory.mustache
@@ -184,7 +184,7 @@ class ApiClientFactory:
         A list of aiohttp TraceConfigs, used to set up request tracing.
         by default None
         """
-        owner = True
+        is_owner = True
         api_config = get_api_configuration(config_loaders=config_loaders)
         api_client_config = api_config.build_api_client_config(
             tcp_keep_alive=tcp_keep_alive,
@@ -198,7 +198,7 @@ class ApiClientFactory:
         try:
             if client_session is not None:
                 connector = client_session.connector
-                owner = False
+                is_owner = False
                 # by default take explicitly passed trace_config param
                 # otherwise copy from session.
                 trace_configs = trace_configs or client_session.trace_configs
@@ -212,7 +212,7 @@ class ApiClientFactory:
                 connector=connector,
                 trust_env=True,
                 trace_configs=trace_configs,
-                connector_owner=owner
+                connector_owner=is_owner
             )
         except AttributeError:
             logger.exception("client_session must be an aiohttp.ClientSession"


### PR DESCRIPTION
# Pull Request Checklist

# Description of the PR
Fixed an issue where the ClientSession object was incorrectly handling the ownership of the connector object. Two tests have been added to handle the cases where the connector object is and isn't provided
