### PR TITLE
wip: correctly converting to strings + added tests for async and sync

### DIFF
--- a/generate/templates/asyncio/rest.mustache
+++ b/generate/templates/asyncio/rest.mustache
@@ -108,8 +108,7 @@ class RESTClientObject:
             headers['Content-Type'] = 'application/json'
         
         for content in headers:
-            if(isinstance(headers[content], (int, float))):
-                headers[content] = ({content: str(headers[content])})
+            headers[content] = ({content: str(headers[content])})
             
 
         args = {

--- a/generate/templates/asyncio/rest.mustache
+++ b/generate/templates/asyncio/rest.mustache
@@ -108,8 +108,8 @@ class RESTClientObject:
             headers['Content-Type'] = 'application/json'
         
         for content in headers:
-            content = ({content: str(headers[content])})
-
+            headers[content] = str(headers[content])
+            
         args = {
             "method": method,
             "url": url,

--- a/generate/templates/asyncio/rest.mustache
+++ b/generate/templates/asyncio/rest.mustache
@@ -108,8 +108,7 @@ class RESTClientObject:
             headers['Content-Type'] = 'application/json'
         
         for content in headers:
-            headers[content] = ({content: str(headers[content])})
-            
+            content = ({content: str(headers[content])})
 
         args = {
             "method": method,

--- a/generate/templates/asyncio/rest.mustache
+++ b/generate/templates/asyncio/rest.mustache
@@ -106,12 +106,19 @@ class RESTClientObject:
 
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'
+        
+        stringified_headers = {}            
+        for content in headers:
+            if(isinstance(headers[content], int)):
+                stringified_headers.update({content: str(headers[content])})
+            else:
+                stringified_headers.update({content: headers[content]})
 
         args = {
             "method": method,
             "url": url,
             "timeout": timeout,
-            "headers": headers
+            "headers": stringified_headers
         }
 
         if self.proxy:

--- a/generate/templates/asyncio/rest.mustache
+++ b/generate/templates/asyncio/rest.mustache
@@ -107,18 +107,16 @@ class RESTClientObject:
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'
         
-        stringified_headers = {}            
         for content in headers:
-            if(isinstance(headers[content], int)):
-                stringified_headers.update({content: str(headers[content])})
-            else:
-                stringified_headers.update({content: headers[content]})
+            if(isinstance(headers[content], (int, float))):
+                headers[content] = ({content: str(headers[content])})
+            
 
         args = {
             "method": method,
             "url": url,
             "timeout": timeout,
-            "headers": stringified_headers
+            "headers": headers
         }
 
         if self.proxy:

--- a/test_sdk/unit/test_api_clients.py
+++ b/test_sdk/unit/test_api_clients.py
@@ -38,7 +38,7 @@ async def test_async_api_client_content_length():
     api_client = AsyncApiClient(config)
     mock_response = MagicMock()
     mock_response.status = "200"
-    headers = {"Content-Type": "text/plain", "Content-Length":17}
+    headers = {"Content-Type": "text/plain", "Content-Length":17, "version": 2.45}
     message = "hello world"
     mock_request = Future()
     mock_request.set_result(mock_response)
@@ -58,7 +58,7 @@ async def test_async_api_client_content_length():
 def test_sync_client_content_length():
     config = Configuration(host="https://www.lusid.com/api")
     api_client = SyncApiClient(config)
-    headers = {"Content-Type": "text/plain", "Content-Length":17}
+    headers = {"Content-Type": "text/plain", "Content-Length":17, "version": 2.45}
     message = "hello world"
 
     with patch.object(

--- a/test_sdk/unit/test_api_clients.py
+++ b/test_sdk/unit/test_api_clients.py
@@ -31,53 +31,6 @@ async def test_async_api_client_encodes_query_params_correctly():
         print(args)
         assert expected_encoded_url == args[1]
 
-@pytest.mark.asyncio
-async def test_async_api_client_content_length():
-    
-    config = Configuration(host="https://www.lusid.com/api")
-    api_client = AsyncApiClient(config)
-    mock_response = MagicMock()
-    mock_response.headers = {"Content-Type": "text/plain", "Content-Length":'17', "version": '2.45'}
-    mock_response.status = '200'
-    headers = {"Content-Type": "text/plain", "Content-Length":17, "version": 2.45}
-    message = "hello world"
-    mock_request = Future()
-    mock_request.set_result(mock_response)
-    with patch.object(
-        api_client, "request", return_value=mock_request
-    ) as mock_request_function:
-
-        result = await api_client.call_api(
-            "/path",
-            "POST",
-            header_params=headers,
-            _preload_content=False,
-            body=message
-        )
-        header_value = list(result.headers.values())[1]
-        assert result.status_code == '200'
-        assert type(header_value) == str
-
-def test_sync_client_content_length():
-    config = Configuration(host="https://www.lusid.com/api")
-    api_client = SyncApiClient(config)
-    headers = {"Content-Type": "text/plain", "Content-Length":17, "version": 2.45}
-    message = "hello world"
-
-    with patch.object(
-        api_client, "request"
-    ) as mock_request_function:
-        mock_request_function.return_value.status = "200"
-        result = api_client.call_api(
-            "/path",
-            "POST",
-            header_params=headers,
-            collection_formats=["multi"],
-            _preload_content=False,
-            body=message
-        )
-        assert result.status_code == '200'
-
 def test_sync_api_client_encodes_query_params_correctly():
     config = Configuration(host="https://example.com")
     api_client = SyncApiClient(config)

--- a/test_sdk/unit/test_api_clients.py
+++ b/test_sdk/unit/test_api_clients.py
@@ -31,6 +31,49 @@ async def test_async_api_client_encodes_query_params_correctly():
         print(args)
         assert expected_encoded_url == args[1]
 
+@pytest.mark.asyncio
+async def test_async_api_client_content_length():
+    
+    config = Configuration(host="https://www.lusid.com/api")
+    api_client = AsyncApiClient(config)
+    mock_response = MagicMock()
+    mock_response.status = "200"
+    headers = {"Content-Type": "text/plain", "Content-Length":17}
+    message = "hello world"
+    mock_request = Future()
+    mock_request.set_result(mock_response)
+    with patch.object(
+        api_client, "request", return_value=mock_request
+    ) as mock_request_function:
+
+        result = await api_client.call_api(
+            "/path",
+            "POST",
+            header_params=headers,
+            _preload_content=False,
+            body=message
+        )
+        assert result.status_code == '200'
+
+def test_sync_client_content_length():
+    config = Configuration(host="https://www.lusid.com/api")
+    api_client = SyncApiClient(config)
+    headers = {"Content-Type": "text/plain", "Content-Length":17}
+    message = "hello world"
+
+    with patch.object(
+        api_client, "request"
+    ) as mock_request_function:
+        mock_request_function.return_value.status = "200"
+        result = api_client.call_api(
+            "/path",
+            "POST",
+            header_params=headers,
+            collection_formats=["multi"],
+            _preload_content=False,
+            body=message
+        )
+        assert result.status_code == '200'
 
 def test_sync_api_client_encodes_query_params_correctly():
     config = Configuration(host="https://example.com")

--- a/test_sdk/unit/test_api_clients.py
+++ b/test_sdk/unit/test_api_clients.py
@@ -37,7 +37,8 @@ async def test_async_api_client_content_length():
     config = Configuration(host="https://www.lusid.com/api")
     api_client = AsyncApiClient(config)
     mock_response = MagicMock()
-    mock_response.status = "200"
+    mock_response.headers = {"Content-Type": "text/plain", "Content-Length":'17', "version": '2.45'}
+    mock_response.status = '200'
     headers = {"Content-Type": "text/plain", "Content-Length":17, "version": 2.45}
     message = "hello world"
     mock_request = Future()
@@ -53,7 +54,9 @@ async def test_async_api_client_content_length():
             _preload_content=False,
             body=message
         )
+        header_value = list(result.headers.values())[1]
         assert result.status_code == '200'
+        assert type(header_value) == str
 
 def test_sync_client_content_length():
     config = Configuration(host="https://www.lusid.com/api")

--- a/test_sdk/unit/test_rest.py
+++ b/test_sdk/unit/test_rest.py
@@ -44,6 +44,11 @@ class TestAsyncRest:
             body=message,
             _preload_content=False,
         )
+
+        args, kwargs = rest_client.pool_manager.request.call_args
+        passed_headers = kwargs['headers']
+
+        assert expected_response == passed_headers
         assert expected_response == response
 
 

--- a/test_sdk/unit/test_rest.py
+++ b/test_sdk/unit/test_rest.py
@@ -26,6 +26,25 @@ class TestAsyncRest:
             _preload_content=False,
         )
         assert expected_response == response
+    
+    @pytest.mark.asyncio
+    async def test_async_api_client_content_length(self):
+        rest_client = lusid.rest.RESTClientObject(lusid.Configuration.get_default())
+        rest_client.pool_manager = AsyncMock(aiohttp.ClientSession)
+
+        expected_response = {"Content-Type": "text/plain", "Content-Length":"17", "version": "2.45"}
+
+        rest_client.pool_manager.request = AsyncMock(return_value=expected_response)
+        headers = {"Content-Type": "text/plain", "Content-Length":17, "version": 2.45}
+        message = "hello world"
+        response = await rest_client.request(
+            "POST",
+            "https://www.lusid.com/api",
+            headers=headers,
+            body=message,
+            _preload_content=False,
+        )
+        assert expected_response == response
 
 
 class TestSyncRest:
@@ -43,6 +62,27 @@ class TestSyncRest:
         response = rest_client.request(
             "PUT",
             "www.example.com",
+            headers=headers,
+            body=message,
+            _preload_content=False,
+        )
+        assert expected_response == response
+
+    def test_sync_client_content_length(self):
+        rest_client = lusid.extensions.rest.RESTClientObject(
+            lusid.Configuration.get_default()
+        )
+        rest_client.pool_manager = MagicMock(aiohttp.ClientSession)
+        expected_headers = {"Content-Type": "text/plain", "Content-Length":"17", "version": "2.45"}
+        expected_response = urllib3.response.HTTPResponse(headers=expected_headers)
+        rest_client.pool_manager.request = MagicMock(return_value=expected_response)
+
+
+        headers = {"Content-Type": "text/plain", "Content-Length":17, "version": 2.45}
+        message = "hello world"
+        response = rest_client.pool_manager.request(
+            "POST",
+            "https://www.lusid.com/api",
             headers=headers,
             body=message,
             _preload_content=False,


### PR DESCRIPTION
# Description of the PR
The Asynchronous Python API client does not correctly handle headers which are not strings - the synchronous client works with these values but async does not.

Fixed the async client, it now correctly converts numbers into strings and added tests for both the Async and Sync versions 
 
