### PR TITLE
Feature/ctools 34 improve sdk v 2 auth in jupyter hub

### DIFF
--- a/generate/config-template.json
+++ b/generate/config-template.json
@@ -46,6 +46,9 @@
         },
         "extensions/tcp_keep_alive_connector.mustache": {
             "destinationFilename": "${PACKAGE_NAME}/extensions/tcp_keep_alive_connector.py"
+        },
+        "extensions/file_access_token.mustache": {
+            "destinationFilename": "${PACKAGE_NAME}/extensions/file_access_token.py"
         }
     }
 }

--- a/generate/templates/__init__package.mustache
+++ b/generate/templates/__init__package.mustache
@@ -27,6 +27,7 @@ from {{packageName}}.extensions import (
     ConfigurationLoader,
     SecretsFileConfigurationLoader,
     EnvironmentVariablesConfigurationLoader,
+    FileTokenConfigurationLoader,
     ArgsConfigurationLoader,
     SyncApiClient
 )
@@ -47,6 +48,8 @@ __all__ = [
     "ConfigurationLoader",
     "SecretsFileConfigurationLoader",
     "EnvironmentVariablesConfigurationLoader",
+    "FileTokenConfigurationLoader",
     "ArgsConfigurationLoader",
     "SyncApiClient"
+    
 ]

--- a/generate/templates/extensions/__init__.mustache
+++ b/generate/templates/extensions/__init__.mustache
@@ -3,6 +3,7 @@ from {{packageName}}.extensions.configuration_loaders import (
     ConfigurationLoader,
     SecretsFileConfigurationLoader,
     EnvironmentVariablesConfigurationLoader,
+    FileTokenConfigurationLoader,
     ArgsConfigurationLoader,
 )
 from {{packageName}}.extensions.api_client import SyncApiClient
@@ -13,6 +14,7 @@ __all__ = [
     "ConfigurationLoader",
     "SecretsFileConfigurationLoader",
     "EnvironmentVariablesConfigurationLoader",
+    "FileTokenConfigurationLoader"
     "ArgsConfigurationLoader",
     "SyncApiClient"
 ]

--- a/generate/templates/extensions/configuration_loaders.mustache
+++ b/generate/templates/extensions/configuration_loaders.mustache
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict, TextIO, Protocol, Union, Iterable
+from typing import Dict, TextIO, Protocol, Union, Iterable, Optional
 import logging
 from {{packageName}}.extensions.proxy_config import ProxyConfig
 from {{packageName}}.extensions.api_configuration import ApiConfiguration
@@ -142,10 +142,34 @@ class EnvironmentVariablesConfigurationLoader:
 class ArgsConfigurationLoader:
     """ConfigurationLoader which loads in config from kwargs in constructor
     """
-    def __init__(self, **kwargs):
+    def __init__(self,
+        token_url:Optional[str]=None,
+        api_url:Optional[str]=None,
+        username:Optional[str]=None,
+        password:Optional[str]=None,
+        client_id:Optional[str]=None,
+        client_secret:Optional[str]=None,
+        app_name:Optional[str]=None,
+        certificate_filename:Optional[str]=None,
+        proxy_address:Optional[str]=None,
+        proxy_username:Optional[str]=None,
+        proxy_password:Optional[str]=None,
+        access_token:Optional[str]=None
+        ):
         """kwargs passed to this constructor used to build ApiConfiguration
         """
-        self._kwargs = kwargs
+        self.__token_url = token_url
+        self.__api_url = api_url
+        self.__username = username
+        self.__password = password
+        self.__client_id = client_id
+        self.__client_secret = client_secret
+        self.__app_name = app_name
+        self.__certificate_filename = certificate_filename
+        self.__proxy_address = proxy_address
+        self.__proxy_username = proxy_username
+        self.__proxy_password = proxy_password
+        self.__access_token = access_token
 
     def load_config(self) -> Dict[str, str]:
         """load configuration from kwargs passed to constructor
@@ -156,8 +180,20 @@ class ArgsConfigurationLoader:
             dictionary that can be loaded into an ApiConfiguration object
         """
         logger.debug("loading config from arguments passed to ArgsConfigurationLoader")
-        keys = ENVIRONMENT_CONFIG_KEYS.keys()
-        return {key: self._kwargs.get(key) for key in keys}
+        return {
+            "token_url" : self.__token_url, 
+            "api_url" : self.__api_url, 
+            "username" : self.__username, 
+            "password" : self.__password, 
+            "client_id" : self.__client_id, 
+            "client_secret" : self.__client_secret, 
+            "app_name" : self.__app_name, 
+            "certificate_filename" : self.__certificate_filename, 
+            "proxy_address" : self.__proxy_address, 
+            "proxy_username" : self.__proxy_username, 
+            "proxy_password" : self.__proxy_password, 
+            "access_token" : self.__access_token
+        }
 
 
 class FileTokenConfigurationLoader:

--- a/generate/templates/extensions/configuration_loaders.mustache
+++ b/generate/templates/extensions/configuration_loaders.mustache
@@ -247,7 +247,7 @@ def get_api_configuration(config_loaders: Iterable[ConfigurationLoader]) -> ApiC
         loaded_config = {
             key: value
             for key, value in config_loader.load_config().items()
-            if value is not None
+            if value is not None and value != None
         }
         config.update(loaded_config)
     proxy_address = config.pop("proxy_address", None)

--- a/generate/templates/extensions/configuration_loaders.mustache
+++ b/generate/templates/extensions/configuration_loaders.mustache
@@ -4,6 +4,7 @@ from typing import Dict, TextIO, Protocol, Union, Iterable
 import logging
 from {{packageName}}.extensions.proxy_config import ProxyConfig
 from {{packageName}}.extensions.api_configuration import ApiConfiguration
+from {{packageName}}.extensions.file_access_token import FileAccessToken
 
 logger = logging.getLogger(__name__)
 
@@ -159,9 +160,35 @@ class ArgsConfigurationLoader:
         return {key: self._kwargs.get(key) for key in keys}
 
 
+class FileTokenConfigurationLoader:
+    """ConfigurationLoader which loads in access token from file
+        if FBN_ACCESS_TOKEN_FILE is set,
+        or if an access_token_location is passed to the initialiser
+    """
+
+    def __init__(
+        self, access_token_location: str = os.getenv("FBN_ACCESS_TOKEN_FILE", "")
+    ):
+        self.access_token = None
+        # if neither are provided we won't want to override config from other loaders
+        if access_token_location is not None and access_token_location != "":
+            self.access_token = FileAccessToken(access_token_location)
+
+    def load_config(self) -> Dict[str, FileAccessToken | None]:
+        """load access token from file
+
+        Returns
+        -------
+        Dict[str, str]
+            dictionary that can be loaded into an ApiConfiguration object
+        """
+        return {"access_token": self.access_token}
+
+
 default_config_loaders = (
     EnvironmentVariablesConfigurationLoader(),
     SecretsFileConfigurationLoader(api_secrets_file="secrets.json"),
+    FileTokenConfigurationLoader()
 )
 
 def get_api_configuration(config_loaders: Iterable[ConfigurationLoader]) -> ApiConfiguration:

--- a/generate/templates/extensions/file_access_token.mustache
+++ b/generate/templates/extensions/file_access_token.mustache
@@ -10,10 +10,11 @@ class FileAccessToken(collections.UserString):
     Acts as a string so can be concatenated to auth headers
     """
 
-    def __init__(self, access_token_location: str):
+    def __init__(self, access_token_location: str, expiry_time:int = 120):
         if access_token_location is None or access_token_location == "":
             raise ValueError("access_token_location must be a non-empty string")
         self.__access_token_location = access_token_location
+        self.__expiry_time = expiry_time 
         self.__token_data = {
             "expires": datetime.datetime.now(),
             "current_access_token": "",
@@ -33,7 +34,7 @@ class FileAccessToken(collections.UserString):
                 with open(self.__access_token_location, "r") as access_token_file:
                     self.__token_data["current_access_token"] = access_token_file.read()
                 self.__token_data["expires"] = (
-                    datetime.datetime.now() + datetime.timedelta(seconds=120)
+                    datetime.datetime.now() + datetime.timedelta(seconds=self.__expiry_time)
                 )
             except OSError:
                 logger.error("Could not open access token file")

--- a/generate/templates/extensions/file_access_token.mustache
+++ b/generate/templates/extensions/file_access_token.mustache
@@ -1,0 +1,41 @@
+import collections
+import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class FileAccessToken(collections.UserString):
+    """Loads access token from file when requested
+    Acts as a string so can be concatenated to auth headers
+    """
+
+    def __init__(self, access_token_location: str):
+        if access_token_location is None or access_token_location == "":
+            raise ValueError("access_token_location must be a non-empty string")
+        self.__access_token_location = access_token_location
+        self.__token_data = {
+            "expires": datetime.datetime.now(),
+            "current_access_token": "",
+        }
+
+    @property
+    def data(self) -> str:
+        """load access token from file
+
+        Returns
+        -------
+        str
+            Access token
+        """
+        if self.__token_data["expires"] <= datetime.datetime.now():
+            try:
+                with open(self.__access_token_location, "r") as access_token_file:
+                    self.__token_data["current_access_token"] = access_token_file.read()
+                self.__token_data["expires"] = (
+                    datetime.datetime.now() + datetime.timedelta(seconds=120)
+                )
+            except OSError:
+                logger.error("Could not open access token file")
+                raise
+        return self.__token_data["current_access_token"]

--- a/test_sdk/unit/test_configuration_loaders.py
+++ b/test_sdk/unit/test_configuration_loaders.py
@@ -228,3 +228,13 @@ class TestFileConfigurationLoader:
             )
             config = config_loader.load_config()
             assert "sample_token" == config["access_token"]
+
+    def test_load_config_returns_no_access_token_when_location_is_empty_string(self):
+        config_loader = FileTokenConfigurationLoader(access_token_location="")
+        config = config_loader.load_config()
+        assert config["access_token"] is None
+
+    def test_load_config_returns_no_access_token_when_location_is_None(self):
+        config_loader = FileTokenConfigurationLoader()
+        config = config_loader.load_config()
+        assert config["access_token"] is None

--- a/test_sdk/unit/test_configuration_loaders.py
+++ b/test_sdk/unit/test_configuration_loaders.py
@@ -3,6 +3,7 @@ from lusid.extensions import (
     SecretsFileConfigurationLoader,
     EnvironmentVariablesConfigurationLoader,
     ArgsConfigurationLoader,
+    FileTokenConfigurationLoader,
 )
 from lusid.extensions.api_client_factory import get_api_configuration
 from unittest import mock
@@ -182,6 +183,15 @@ def test_get_api_configuration_overwrites_content_in_order():
     assert api_config.token_url == "2"
 
 
+def test_get_api_configuration_does_not_overwrite_content_when_value_None():
+    mock_config_loader_1 = EnvironmentVariablesConfigurationLoader()
+    mock_config_loader_1.load_config = mock.MagicMock(return_value={"token_url": "1"})
+    mock_config_loader_2 = EnvironmentVariablesConfigurationLoader()
+    mock_config_loader_2.load_config = mock.MagicMock(return_value={"token_url": None})
+    api_config = get_api_configuration([mock_config_loader_1, mock_config_loader_2])
+    assert api_config.token_url == "1"
+
+
 def test_get_api_configuration_returns_api_config_with_proxy_settings_when_proxy_address_not_None():  # noqa
     proxy_address = "http://www.example.com"
     mock_config_loader = EnvironmentVariablesConfigurationLoader()
@@ -208,3 +218,13 @@ def test_get_api_configuration_returns_api_config_with_proxy_address_and_usernam
     assert api_config.proxy_config.address == proxy_address
     assert api_config.proxy_config.username == proxy_username
     assert api_config.proxy_config.password == proxy_password
+
+
+class TestFileConfigurationLoader:
+    def test_load_config_returns_access_token_from_file(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data="sample_token")):
+            config_loader = FileTokenConfigurationLoader(
+                access_token_location="test_file"
+            )
+            config = config_loader.load_config()
+            assert "sample_token" == config["access_token"]

--- a/test_sdk/unit/test_file_access_token.py
+++ b/test_sdk/unit/test_file_access_token.py
@@ -1,0 +1,28 @@
+from lusid.extensions.file_access_token import FileAccessToken
+from unittest import mock
+import time
+
+from more_itertools import side_effect
+
+
+class TestFileAccessToken:
+    def test_file_access_token_loads_token_from_file(self):
+        with mock.patch(
+            "builtins.open", mock.mock_open(read_data="sample_token")
+        ) as mock_file:
+            token = FileAccessToken(access_token_location="test_file")
+            assert "sample_token" == token
+            mock_file.assert_called_once_with("test_file", "r")
+
+    def test_file_access_token_refreshed_token_when_expired(self):
+        mock_file_1 = mock.MagicMock()
+        mock_file_1.__enter__.return_value = mock_file_1
+        mock_file_1.read.return_value = "token1"
+        mock_file_2 = mock.MagicMock()
+        mock_file_2.__enter__.return_value = mock_file_2
+        mock_file_2.read.return_value = "token2"
+        with mock.patch("builtins.open", side_effect=[mock_file_1, mock_file_2]):
+            token = FileAccessToken(access_token_location="test_file", expiry_time=2)
+            assert "token1" == token
+            time.sleep(3)
+            assert "token2" == token


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

While RefreshingToken may evaluate to None, its not the same as a None value - this change just adds an extra check on api config values so Null Refreshing Tokens are ignored.