### PR TITLE
[PROPOSAL] Update the `generate-cicd` recipe to fail gracefully for missing library template

### DIFF
--- a/justfile
+++ b/justfile
@@ -141,7 +141,13 @@ generate-cicd TARGET_DIR FLAG="":
     mkdir -p ./generate/.output
     envsubst < generate/config-template.json > generate/.config.json
     cp ./generate/.openapi-generator-ignore ./generate/.output/.openapi-generator-ignore
-    cp ./generate/templates/description.{{APPLICATION_NAME}}.mustache ./generate/templates/description.mustache
+    # Basic check if file exists
+    if [ -f "./generate/templates/description.{{APPLICATION_NAME}}.mustache" ]; then
+        cp ./generate/templates/description.{{APPLICATION_NAME}}.mustache ./generate/templates/description.mustache
+    else
+        echo "No description template for {{ APPLICATION_NAME }} ... skipping."
+    fi
+    
 
     ./generate/generate.sh ./generate ./generate/.output {{swagger_path}} .config.json
     rm -f generate/.output/.openapi-generator-ignore


### PR DESCRIPTION
# Pull Request Checklist

- [ X] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch <- doesn't exist

# Description of the PR

This PR is adding a check for the existence of a ```description.{{APPLICATION_NAME}}.mustache``` file in the `generate/templates` directory that fails gracefully if that file is missing. 

As we use this repo internally to build all our SDK's it should fail gracefully if if there is no description template added here. Otherwise the 2 repositories are too tightly coupled.