### PR TITLE
CAN-16: fix syntax for justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -149,7 +149,7 @@ generate-cicd TARGET_DIR FLAG="":
     cp ./generate/.openapi-generator-ignore ./generate/.output/.openapi-generator-ignore
     # Basic check if file exists
     if [ -f "./generate/templates/description.{{APPLICATION_NAME}}.mustache" ]; then \
-        cp ./generate/templates/description.{{APPLICATION_NAME}}.mustache ./generate/templates/description.mustache;
+        cp ./generate/templates/description.{{APPLICATION_NAME}}.mustache ./generate/templates/description.mustache; \
     else \
         echo "[INTERNAL] FINBOURNE Technology {{APPLICATION_NAME}} SDK" > ./generate/templates/description.mustache; \
         echo "[INFO] No description template found for {{APPLICATION_NAME}} - if this is an external facing SDK - add ./generate/templates/description.{{APPLICATION_NAME}}.mustache to this project ASAP";\


### PR DESCRIPTION
### Background

- Hotfix for error introduces in #44 
- `generate-local` was heavily tested and `generate-cicd` slipped through the net

### How were the changes implemented

- Add trailing backslash to bash command in justfile 

## How Has This Been Tested?

- [X] Ran `generate-local` locally
- [X] Ran `generate-cicd` locally

### How this can be tested

1. Pull branch down
2. Run `just generate-cicd`
3. The process will fail on `The operation couldn’t be completed. Unable to locate a Java Runtime.` which is already passed the code that breaks the pipelines

