### PR TITLE
Feature/ctools 445

### DIFF
--- a/generate/default_templates/model_anyof.mustache
+++ b/generate/default_templates/model_anyof.mustache
@@ -146,6 +146,11 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             return instance
 
+    def __repr__(self) -> str:
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+
     def to_json(self) -> str:
         """Returns the JSON representation of the actual instance"""
         if self.actual_instance is None:

--- a/generate/default_templates/model_anyof.mustache
+++ b/generate/default_templates/model_anyof.mustache
@@ -170,7 +170,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def __str__(self):
         """For `print` and `pprint`"""
-        return self.to_str()
+        return pprint.pformat(self.dict(by_alias=False))
 
     def __repr__(self):
         """For `print` and `pprint`"""
@@ -178,7 +178,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""
-        return pprint.pformat(self.dict(by_alias=False))
+        return pprint.pformat(self.dict(by_alias=True))
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}
 {{#vendorExtensions.x-py-postponed-model-imports}}

--- a/generate/default_templates/model_anyof.mustache
+++ b/generate/default_templates/model_anyof.mustache
@@ -146,11 +146,6 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             return instance
 
-    def __repr__(self) -> str:
-        """For `print` and `pprint`"""
-        return self.to_str()
-
-
     def to_json(self) -> str:
         """Returns the JSON representation of the actual instance"""
         if self.actual_instance is None:
@@ -173,9 +168,17 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             return json.dumps(self.actual_instance)
 
+    def __str__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
     def to_str(self) -> str:
-        """Returns the string representation of the actual instance"""
-        return pprint.pformat(self.dict())
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.dict(by_alias=False))
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}
 {{#vendorExtensions.x-py-postponed-model-imports}}

--- a/generate/default_templates/model_generic.mustache
+++ b/generate/default_templates/model_generic.mustache
@@ -112,7 +112,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 {{/hasChildren}}
     def __str__(self):
         """For `print` and `pprint`"""
-        return self.to_str()
+        return pprint.pformat(self.dict(by_alias=False))
 
     def __repr__(self):
         """For `print` and `pprint`"""
@@ -120,7 +120,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""
-        return pprint.pformat(self.dict(by_alias=False))
+        return pprint.pformat(self.dict(by_alias=True))
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""

--- a/generate/default_templates/model_generic.mustache
+++ b/generate/default_templates/model_generic.mustache
@@ -110,6 +110,10 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
 {{/discriminator}}
 {{/hasChildren}}
+    def __repr__(self) -> str:
+        """For `print` and `pprint`"""
+        return self.to_str()
+
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""
         return pprint.pformat(self.dict(by_alias=True))

--- a/generate/default_templates/model_generic.mustache
+++ b/generate/default_templates/model_generic.mustache
@@ -110,13 +110,17 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
 {{/discriminator}}
 {{/hasChildren}}
-    def __repr__(self) -> str:
+    def __str__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __repr__(self):
         """For `print` and `pprint`"""
         return self.to_str()
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""
-        return pprint.pformat(self.dict(by_alias=True))
+        return pprint.pformat(self.dict(by_alias=False))
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""

--- a/generate/default_templates/model_oneof.mustache
+++ b/generate/default_templates/model_oneof.mustache
@@ -197,6 +197,11 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     def to_str(self) -> str:
         """Returns the string representation of the actual instance"""
         return pprint.pformat(self.dict())
+    
+    def __repr__(self) -> str:
+        """For `print` and `pprint`"""
+        return self.to_str()
+
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}
 {{#vendorExtensions.x-py-postponed-model-imports}}

--- a/generate/default_templates/model_oneof.mustache
+++ b/generate/default_templates/model_oneof.mustache
@@ -196,7 +196,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def __str__(self):
         """For `print` and `pprint`"""
-        return self.to_str()
+        return pprint.pformat(self.dict(by_alias=False))
 
     def __repr__(self):
         """For `print` and `pprint`"""
@@ -204,7 +204,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""
-        return pprint.pformat(self.dict(by_alias=False))
+        return pprint.pformat(self.dict(by_alias=True))
 
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}

--- a/generate/default_templates/model_oneof.mustache
+++ b/generate/default_templates/model_oneof.mustache
@@ -194,13 +194,17 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             # primitive type
             return self.actual_instance
 
-    def to_str(self) -> str:
-        """Returns the string representation of the actual instance"""
-        return pprint.pformat(self.dict())
-    
-    def __repr__(self) -> str:
+    def __str__(self):
         """For `print` and `pprint`"""
         return self.to_str()
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.dict(by_alias=False))
 
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}

--- a/generate/templates/model_anyof.mustache
+++ b/generate/templates/model_anyof.mustache
@@ -148,7 +148,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def __str__(self):
         """For `print` and `pprint`"""
-        return pprint.pformat(self.dict(by_alias=Fale))
+        return pprint.pformat(self.dict(by_alias=False))
 
     def __repr__(self):
         """For `print` and `pprint`"""

--- a/generate/templates/model_anyof.mustache
+++ b/generate/templates/model_anyof.mustache
@@ -148,7 +148,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def __str__(self):
         """For `print` and `pprint`"""
-        return self.to_str()
+        return pprint.pformat(self.dict(by_alias=Fale))
 
     def __repr__(self):
         """For `print` and `pprint`"""
@@ -156,7 +156,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""
-        return pprint.pformat(self.dict(by_alias=False))
+        return pprint.pformat(self.dict(by_alias=True))
 
     def to_json(self) -> str:
         """Returns the JSON representation of the actual instance"""

--- a/generate/templates/model_anyof.mustache
+++ b/generate/templates/model_anyof.mustache
@@ -146,9 +146,17 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             return instance
 
-    def __repr__(self) -> str:
+    def __str__(self):
         """For `print` and `pprint`"""
         return self.to_str()
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.dict(by_alias=False))
 
     def to_json(self) -> str:
         """Returns the JSON representation of the actual instance"""
@@ -172,9 +180,6 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             return json.dumps(self.actual_instance)
 
-    def to_str(self) -> str:
-        """Returns the string representation of the actual instance"""
-        return pprint.pformat(self.dict())
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}
 {{#vendorExtensions.x-py-postponed-model-imports}}

--- a/generate/templates/model_anyof.mustache
+++ b/generate/templates/model_anyof.mustache
@@ -146,6 +146,10 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             return instance
 
+    def __repr__(self) -> str:
+        """For `print` and `pprint`"""
+        return self.to_str()
+
     def to_json(self) -> str:
         """Returns the JSON representation of the actual instance"""
         if self.actual_instance is None:

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -112,7 +112,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 {{/hasChildren}}
     def __str__(self):
         """For `print` and `pprint`"""
-        return self.to_str()
+        return pprint.pformat(self.dict(by_alias=False))
 
     def __repr__(self):
         """For `print` and `pprint`"""
@@ -120,7 +120,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""
-        return pprint.pformat(self.dict(by_alias=False))
+        return pprint.pformat(self.dict(by_alias=True))
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -110,6 +110,10 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
 {{/discriminator}}
 {{/hasChildren}}
+    def __repr__(self) -> str:
+        """For `print` and `pprint`"""
+        return self.to_str()
+
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""
         return pprint.pformat(self.dict(by_alias=True))

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -110,13 +110,17 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
 {{/discriminator}}
 {{/hasChildren}}
-    def __repr__(self) -> str:
+    def __str__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __repr__(self):
         """For `print` and `pprint`"""
         return self.to_str()
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""
-        return pprint.pformat(self.dict(by_alias=True))
+        return pprint.pformat(self.dict(by_alias=False))
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""

--- a/generate/templates/model_oneof.mustache
+++ b/generate/templates/model_oneof.mustache
@@ -194,13 +194,17 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             # primitive type
             return self.actual_instance
 
-    def to_str(self) -> str:
-        """Returns the string representation of the actual instance"""
-        return pprint.pformat(self.dict())
-        
-    def __repr__(self) -> str:
-        """For `print` and `pprint`"""
-        return self.to_str()
+        def __str__(self):
+            """For `print` and `pprint`"""
+            return self.to_str()
+    
+        def __repr__(self):
+            """For `print` and `pprint`"""
+            return self.to_str()
+    
+        def to_str(self) -> str:
+            """Returns the string representation of the model using alias"""
+            return pprint.pformat(self.dict(by_alias=False))
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}
 {{#vendorExtensions.x-py-postponed-model-imports}}

--- a/generate/templates/model_oneof.mustache
+++ b/generate/templates/model_oneof.mustache
@@ -197,6 +197,10 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     def to_str(self) -> str:
         """Returns the string representation of the actual instance"""
         return pprint.pformat(self.dict())
+        
+    def __repr__(self) -> str:
+        """For `print` and `pprint`"""
+        return self.to_str()
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}
 {{#vendorExtensions.x-py-postponed-model-imports}}

--- a/generate/templates/model_oneof.mustache
+++ b/generate/templates/model_oneof.mustache
@@ -196,7 +196,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
         def __str__(self):
             """For `print` and `pprint`"""
-            return self.to_str()
+            return pprint.pformat(self.dict(by_alias=False))
     
         def __repr__(self):
             """For `print` and `pprint`"""
@@ -204,7 +204,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     
         def to_str(self) -> str:
             """Returns the string representation of the model using alias"""
-            return pprint.pformat(self.dict(by_alias=False))
+            return pprint.pformat(self.dict(by_alias=True))
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}
 {{#vendorExtensions.x-py-postponed-model-imports}}


### PR DESCRIPTION
Changes cause print(obj) to show the Model objects in the same format as the v1 of the SDK.

Tested on the a concourse test-sdk-generation pipeline.



**Before:**
**Print()**
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
with_path='pathinfo_with_path' name='jason'
**_ _str_ _**
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
with_path='pathinfo_with_path' name='jason'
**_ _repr_ _**
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
SearchBody(with_path='pathinfo_with_path', name='jason')
**to_str()**
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
{'name': 'jason', 'withPath': 'pathinfo_with_path'}
**to_dict()**
{'with_path': 'pathinfo_with_path', 'name': 'jason'}
{'withPath': 'pathinfo_with_path', 'name': 'jason'}

**After**
**Print**
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
**___ __str__ __**
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
**__ __repr__ __**
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
{'name': 'jason', 'withPath': 'pathinfo_with_path'}
**to_str()**
{'name': 'jason', 'with_path': 'pathinfo_with_path'}
{'name': 'jason', 'withPath': 'pathinfo_with_path'}
**to_dict()**
{'with_path': 'pathinfo_with_path', 'name': 'jason'}
{'withPath': 'pathinfo_with_path', 'name': 'jason'}
