### PR TITLE
Feature/ctools 434

### DIFF
--- a/generate/templates/api_test.mustache
+++ b/generate/templates/api_test.mustache
@@ -45,34 +45,6 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
         while numRuns < numExamples:
             numRuns += 1
             {{#allParams}}
-            {{#vendorExtensions.x-regex}}
-            minLength = {{#schema.minLength}}{{schema.minLength}}{{/schema.minLength}}{{^schema.minLength}}0{{/schema.minLength}}
-            maxLength = {{#schema.maxLength}}{{schema.maxLength}}{{/schema.maxLength}}{{^schema.maxLength}}10{{/schema.maxLength}}
-            # the following is necessary to avoid url becoming longer than acceptable length
-            if maxLength > 50:
-                maxLength = 50
-            xegerObj = Xeger(limit=maxLength)
-            count = 0
-            while True:
-                count += 1
-                regex = r"{{{vendorExtensions.x-regex}}}"
-                # The regex map is required due to a limitation of Xeger library where it fails 
-                # correctly generate the string from the regex
-                regex_map = {
-                    r'^(?=.*[a-zA-Z])[\w][\w +-]{2,100}$': "official-portfolios-read-only",
-                    r'^[a-zA-Z0-9\\+/]*={0,3}$': "L=="
-                }
-
-                {{paramName}}: {{{dataType}}} = xegerObj.xeger(r"{{{vendorExtensions.x-regex}}}")
-
-                if regex in regex_map:
-                    {{paramName}} = regex_map[regex]
-
-                if len({{paramName}}) >= minLength:
-                    break
-                if count > 10000:
-                    raise Exception("unable to generate random value for parameter {{paramName}} which matches the constraints")
-            {{/vendorExtensions.x-regex}}
             {{^vendorExtensions.x-regex}}
             {{#isPrimitiveType}}
             {{#isUuid}}

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -5,7 +5,7 @@ import json
 
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}, Field
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -20,34 +20,18 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     {{#description}}{{{description}}}  # noqa: E501{{/description}}{{^description}}{{{classname}}}{{/description}}
     """
 {{#vars}}
+    {{^isString}}
     {{name}}: {{{vendorExtensions.x-py-typing}}}
+    {{/isString}}
+    {{#isString}}
+    {{name}}: constr(strict=True) = Field({{#required}}...{{/required}}{{^required}}None{{/required}},alias="{{baseName}}"{{#description}}, description="{{description}}"{{/description}}) 
+    {{/isString}}
 {{/vars}}
 {{#isAdditionalPropertiesTrue}}
     additional_properties: Dict[str, Any] = {}
 {{/isAdditionalPropertiesTrue}}
     __properties = [{{#allVars}}"{{baseName}}"{{^-last}}, {{/-last}}{{/allVars}}]
 {{#vars}}
-    {{#vendorExtensions.x-regex}}
-
-    @validator('{{{name}}}')
-    def {{{name}}}_validate_regular_expression(cls, value):
-        """Validates the regular expression"""
-        {{^required}}
-        if value is None:
-            return value
-
-        {{/required}}
-        {{#required}}
-        {{#isNullable}}
-        if value is None:
-            return value
-
-        {{/isNullable}}
-        {{/required}}
-        if not re.match(r"{{{.}}}", value{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
-            raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
-        return value
-    {{/vendorExtensions.x-regex}}
     {{#isEnum}}
 
     @validator('{{{name}}}')


### PR DESCRIPTION

**Requirement**

- For the model objects (DTOs) a change for string types only.
- Remain on pydantic.v1 namespace
- To remove string length and regex validations client side, but still enforcing typing.
- For example stringValue = 1 for throw ValidationError as type coercion isn't permitted.
- Optional and mandatory string parameters remain enforced by pydantic.
- The changes only effect sting types.

**Solved By** 

- The property definition uses a re-worked pydantic definition to create a constraint which doesn't include the min and max length for the string.
- Removed the generation of regex expression validations for strings


