### PR TITLE
Feature/ctools 486

### DIFF
--- a/generate/templates/api_test.mustache
+++ b/generate/templates/api_test.mustache
@@ -41,6 +41,8 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
    {{#operation}}
     @pytest.mark.asyncio
     async def test_{{operationId}}(self) -> None:
+
+        requestBodyByteArray: bytearray = "SomeContentForRequestBody"
         numRuns = 0
         numExamples = 1
         while numRuns < numExamples:
@@ -86,7 +88,14 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
             {{^isUuid}}
             {{#isQueryParam}}# isQueryParam {{/isQueryParam}}
             {{#isString}}# is string{{/isString}}
+            {{#isByteArray}}# isByteArray{{/isByteArray}}
+            {{^isByteArray}}
             {{paramName}}: {{{dataType}}} = {{^isQueryParam}}{{#isString}}"""{{/isString}}{{/isQueryParam}}{{{example}}}{{^isQueryParam}}{{#isString}}"""{{/isString}}{{/isQueryParam}}
+            {{/isByteArray}}
+            {{#isByteArray}}
+            {{paramName}}: {{{dataType}}} = requestBodyByteArray
+            content_length = len(requestBodyByteArray)
+            {{/isByteArray}}
             {{/isUuid}}
             {{/isPrimitiveType}}
             {{^isPrimitiveType}}
@@ -137,6 +146,7 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
             {{/isPrimitiveType}}
             {{/vendorExtensions.x-regex}}
             {{/allParams}}
+            
             {{#returnType}}response = {{/returnType}}await self.api.{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
             {{#returnType}}
             assert(response is not None)

--- a/generate/templates/api_test.mustache
+++ b/generate/templates/api_test.mustache
@@ -5,6 +5,7 @@
 from typing import List, Dict
 import unittest
 import json
+import datetime
 from xeger import Xeger
 from {{modelPackage}} import *
 import os
@@ -22,7 +23,7 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
         if "BASE_URL" in os.environ:
             api_url = os.environ["BASE_URL"]
         else:
-            api_url = "http://localhost:5000"
+            api_url = "http://localhost:5000/honeycomb"
         config_loaders = [
             ArgsConfigurationLoader(api_url=api_url, access_token="UNUSED")
         ]
@@ -83,7 +84,9 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
                 {{paramName}}: {{{dataType}}} = {{{example}}}
             {{/isUuid}}
             {{^isUuid}}
-            {{paramName}}: {{{dataType}}} = {{{example}}}
+            {{#isQueryParam}}# isQueryParam {{/isQueryParam}}
+            {{#isString}}# is string{{/isString}}
+            {{paramName}}: {{{dataType}}} = {{^isQueryParam}}{{#isString}}"""{{/isString}}{{/isQueryParam}}{{{example}}}{{^isQueryParam}}{{#isString}}"""{{/isString}}{{/isQueryParam}}
             {{/isUuid}}
             {{/isPrimitiveType}}
             {{^isPrimitiveType}}
@@ -111,9 +114,25 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
             {{/content}}
             {{^content}}
             {{#isArray}}
-            {{paramName}}: {{{dataType}}} = {{{example}}}{{/isArray}}
+            # isArray
+            {{paramName}}: {{{dataType}}} =  {{{example}}}
+            {{/isArray}}
             {{^isArray}}
-            {{paramName}}: {{{dataType}}} = json.loads("""{{{example}}}"""){{/isArray}}
+            # ^isArray
+            {{#isEnumRef}}
+            # isEnumRef
+            {{paramName}}: {{{dataType}}} = {{{schema.example}}}
+            {{/isEnumRef}}
+            {{^isEnumRef}}
+            {{#isExplode}}
+            # isExplode
+            {{paramName}}: {{{dataType}}} = {{{example}}}
+            {{/isExplode}}
+            {{^isExplode}}
+            {{paramName}}: {{{dataType}}} = json.loads("""{{{example}}}""")
+            {{/isExplode}}
+            {{/isEnumRef}}
+            {{/isArray}}
             {{/content}}
             {{/isPrimitiveType}}
             {{/vendorExtensions.x-regex}}

--- a/generate/templates/api_test.mustache
+++ b/generate/templates/api_test.mustache
@@ -108,7 +108,6 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
                 openapiSpecJson = file.read()
 
             print("spec_filepath="+spec_filepath)
-            print(openapiSpecJson)
             
             method = "{{httpMethod}}".replace("Http", "").lower()
             jsonContent = json.loads(openapiSpecJson)

--- a/generate/templates/api_test.mustache
+++ b/generate/templates/api_test.mustache
@@ -42,6 +42,9 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     async def test_{{operationId}}(self) -> None:
 
+        if "{{vendorExtensions.x-fbn-apistatus}}" == "Experimental":
+            return
+
         requestBodyByteArray: bytearray = "SomeContentForRequestBody"
         numRuns = 0
         numExamples = 1

--- a/generate/templates/api_test.mustache
+++ b/generate/templates/api_test.mustache
@@ -23,7 +23,7 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
         if "BASE_URL" in os.environ:
             api_url = os.environ["BASE_URL"]
         else:
-            api_url = "http://localhost:5000/honeycomb"
+            api_url = "http://localhost:5000"
         config_loaders = [
             ArgsConfigurationLoader(api_url=api_url, access_token="UNUSED")
         ]

--- a/generate/templates/api_test.mustache
+++ b/generate/templates/api_test.mustache
@@ -5,7 +5,6 @@
 from typing import List, Dict
 import unittest
 import json
-import datetime
 from xeger import Xeger
 from {{modelPackage}} import *
 import os
@@ -89,9 +88,6 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
                 {{paramName}}: {{{dataType}}} = {{{example}}}
             {{/isUuid}}
             {{^isUuid}}
-            {{#isQueryParam}}# isQueryParam {{/isQueryParam}}
-            {{#isString}}# is string{{/isString}}
-            {{#isByteArray}}# isByteArray{{/isByteArray}}
             {{^isByteArray}}
             {{paramName}}: {{{dataType}}} = {{^isQueryParam}}{{#isString}}"""{{/isString}}{{/isQueryParam}}{{{example}}}{{^isQueryParam}}{{#isString}}"""{{/isString}}{{/isQueryParam}}
             {{/isByteArray}}
@@ -106,9 +102,7 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
             spec_filepath = os.environ['OPENAPI_SPEC_PATH']
             with open(spec_filepath) as file:
                 openapiSpecJson = file.read()
-
-            print("spec_filepath="+spec_filepath)
-            
+          
             method = "{{httpMethod}}".replace("Http", "").lower()
             jsonContent = json.loads(openapiSpecJson)
             jsonContent = jsonContent["paths"]["{{path}}"][method]["requestBody"]["content"]["application/json"]
@@ -128,18 +122,14 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
             {{/content}}
             {{^content}}
             {{#isArray}}
-            # isArray
             {{paramName}}: {{{dataType}}} =  {{{example}}}
             {{/isArray}}
             {{^isArray}}
-            # ^isArray
             {{#isEnumRef}}
-            # isEnumRef
             {{paramName}}: {{{dataType}}} = {{{schema.example}}}
             {{/isEnumRef}}
             {{^isEnumRef}}
             {{#isExplode}}
-            # isExplode
             {{paramName}}: {{{dataType}}} = {{{example}}}
             {{/isExplode}}
             {{^isExplode}}
@@ -151,7 +141,6 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
             {{/isPrimitiveType}}
             {{/vendorExtensions.x-regex}}
             {{/allParams}}
-            
             {{#returnType}}response = {{/returnType}}await self.api.{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
             {{#returnType}}
             assert(response is not None)

--- a/generate/templates/api_test.mustache
+++ b/generate/templates/api_test.mustache
@@ -106,6 +106,9 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
             spec_filepath = os.environ['OPENAPI_SPEC_PATH']
             with open(spec_filepath) as file:
                 openapiSpecJson = file.read()
+
+            print("spec_filepath="+spec_filepath)
+            print(openapiSpecJson)
             
             method = "{{httpMethod}}".replace("Http", "").lower()
             jsonContent = json.loads(openapiSpecJson)

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -5,7 +5,7 @@ import json
 
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-from pydantic.v1 import Field{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}},{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -5,7 +5,7 @@ import json
 
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+from pydantic.v1 import Field{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}},{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -5,7 +5,7 @@ import json
 
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-from pydantic.v1 import constr, Field{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}},{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}
@@ -19,19 +19,35 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     """
     {{#description}}{{{description}}}  # noqa: E501{{/description}}{{^description}}{{{classname}}}{{/description}}
     """
-    {{#vars}}
-    {{^isString}}
+{{#vars}}
     {{name}}: {{{vendorExtensions.x-py-typing}}}
-    {{/isString}}
-    {{#isString}}
-    {{name}}:  {{^required}}Optional[{{/required}}constr(strict=True){{^required}}]{{/required}} = Field({{#required}}...{{/required}}{{^required}}None{{/required}},alias="{{baseName}}"{{#description}}, description="{{description}}"{{/description}}) 
-    {{/isString}}
-    {{/vars}}
+{{/vars}}
 {{#isAdditionalPropertiesTrue}}
     additional_properties: Dict[str, Any] = {}
 {{/isAdditionalPropertiesTrue}}
     __properties = [{{#allVars}}"{{baseName}}"{{^-last}}, {{/-last}}{{/allVars}}]
 {{#vars}}
+    {{#vendorExtensions.x-regex}}
+
+    @validator('{{{name}}}')
+    def {{{name}}}_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        {{^required}}
+        if value is None:
+            return value
+
+        {{/required}}
+        {{#required}}
+        {{#isNullable}}
+        if value is None:
+            return value
+
+        {{/isNullable}}
+        {{/required}}
+        if not re.match(r"{{{.}}}", value{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
+            raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
+        return value
+    {{/vendorExtensions.x-regex}}
     {{#isEnum}}
 
     @validator('{{{name}}}')

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -5,7 +5,7 @@ import json
 
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+from pydantic.v1 import constr, Field{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}},{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}
@@ -19,35 +19,19 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     """
     {{#description}}{{{description}}}  # noqa: E501{{/description}}{{^description}}{{{classname}}}{{/description}}
     """
-{{#vars}}
+    {{#vars}}
+    {{^isString}}
     {{name}}: {{{vendorExtensions.x-py-typing}}}
-{{/vars}}
+    {{/isString}}
+    {{#isString}}
+    {{name}}:  {{^required}}Optional[{{/required}}constr(strict=True){{^required}}]{{/required}} = Field({{#required}}...{{/required}}{{^required}}None{{/required}},alias="{{baseName}}"{{#description}}, description="{{description}}"{{/description}}) 
+    {{/isString}}
+    {{/vars}}
 {{#isAdditionalPropertiesTrue}}
     additional_properties: Dict[str, Any] = {}
 {{/isAdditionalPropertiesTrue}}
     __properties = [{{#allVars}}"{{baseName}}"{{^-last}}, {{/-last}}{{/allVars}}]
 {{#vars}}
-    {{#vendorExtensions.x-regex}}
-
-    @validator('{{{name}}}')
-    def {{{name}}}_validate_regular_expression(cls, value):
-        """Validates the regular expression"""
-        {{^required}}
-        if value is None:
-            return value
-
-        {{/required}}
-        {{#required}}
-        {{#isNullable}}
-        if value is None:
-            return value
-
-        {{/isNullable}}
-        {{/required}}
-        if not re.match(r"{{{.}}}", value{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
-            raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
-        return value
-    {{/vendorExtensions.x-regex}}
     {{#isEnum}}
 
     @validator('{{{name}}}')

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -5,7 +5,7 @@ import json
 
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-from pydantic.v1 import constr, Field{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}},{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+from pydantic.v1 import Field{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}},{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -5,7 +5,7 @@ import json
 
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-from pydantic.v1 import Field{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}},{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+from pydantic.v1 import constr, Field{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}},{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}

--- a/justfile
+++ b/justfile
@@ -74,9 +74,9 @@ generate-local FLAG="":
     if [ "{{APPLICATION_NAME}}" = "access" ]; then just make-import-fix; fi
 
 add-tests:
-    mkdir -p {{justfile_directory()}}/generate/.output/sdk/test/
-    rm -rf {{justfile_directory()}}/generate/.output/sdk/test/*
-    cp -R {{justfile_directory()}}/test_sdk/* {{justfile_directory()}}/generate/.output/sdk/test
+    mkdir -p {{justfile_directory()}}/generate/.output/sdk/test/app
+    rm -rf {{justfile_directory()}}/generate/.output/sdk/test/app/*
+    cp -R {{justfile_directory()}}/test_sdk/* {{justfile_directory()}}/generate/.output/sdk/test/app
 
     # these test files have been copied from the lusid sdk tests
     # rename to match values for the sdk being tested
@@ -84,21 +84,21 @@ add-tests:
 
     # note the default values at the top of this justfile won't work for the horizon or luminesce sdk
     # (they don't have this api/method)
-    find {{justfile_directory()}}/generate/.output/sdk/test -type f -exec sed -i -e "s/TEST_API_MODULE/${TEST_API_MODULE}/g" {} \;
-    find {{justfile_directory()}}/generate/.output/sdk/test -type f -exec sed -i -e "s/TEST_API/${TEST_API}/g" {} \;
-    find {{justfile_directory()}}/generate/.output/sdk/test -type f -exec sed -i -e "s/TEST_METHOD/${TEST_METHOD}/g" {} \;
+    find {{justfile_directory()}}/generate/.output/sdk/test/app -type f -exec sed -i -e "s/TEST_API_MODULE/${TEST_API_MODULE}/g" {} \;
+    find {{justfile_directory()}}/generate/.output/sdk/test/app -type f -exec sed -i -e "s/TEST_API/${TEST_API}/g" {} \;
+    find {{justfile_directory()}}/generate/.output/sdk/test/app -type f -exec sed -i -e "s/TEST_METHOD/${TEST_METHOD}/g" {} \;
 
 link-tests-cicd TARGET_DIR:
-    mkdir -p {{TARGET_DIR}}/sdk/test/
-    rm -rf {{TARGET_DIR}}/sdk/test/*
-    ln -s {{justfile_directory()}}/test_sdk/* {{TARGET_DIR}}/sdk/test
+    mkdir -p {{TARGET_DIR}}/sdk/test/app
+    rm -rf {{TARGET_DIR}}/sdk/test/app/*
+    cp -R {{justfile_directory()}}/test_sdk/* {{TARGET_DIR}}/sdk/test/app
 
     # these test files have been copied from the lusid sdk tests
     # rename to match values for the sdk being tested
-    find {{justfile_directory()}}/test_sdk -type f -exec sed -i -e "s/TO_BE_REPLACED/${PLACEHOLDER_VALUE_FOR_TESTS}/g" {} \;
-    find {{justfile_directory()}}/test_sdk -type f -exec sed -i -e "s/TEST_API_MODULE/${TEST_API_MODULE}/g" {} \;
-    find {{justfile_directory()}}/test_sdk -type f -exec sed -i -e "s/TEST_API/${TEST_API}/g" {} \;
-    find {{justfile_directory()}}/test_sdk -type f -exec sed -i -e "s/TEST_METHOD/${TEST_METHOD}/g" {} \;
+    find {{TARGET_DIR}}/sdk/test/app -type f -exec sed -i -e "s/TO_BE_REPLACED/${PLACEHOLDER_VALUE_FOR_TESTS}/g" {} \;
+    find {{TARGET_DIR}}/sdk/test/app -type f -exec sed -i -e "s/TEST_API_MODULE/${TEST_API_MODULE}/g" {} \;
+    find {{TARGET_DIR}}/sdk/test/app -type f -exec sed -i -e "s/TEST_API/${TEST_API}/g" {} \;
+    find {{TARGET_DIR}}/sdk/test/app -type f -exec sed -i -e "s/TEST_METHOD/${TEST_METHOD}/g" {} \;
  
 setup-test-local:
     @just generate-local


### PR DESCRIPTION
**Why**
This change ensures the tests for exercising the API's are generated.  Each application now has it's API endpoints exercised if not  'experimental'. The experimental endpoints were too 'messy' i.e. missing examples.

**Changes Made**
The api_test.mustache needed many changes to handle the different data types used as parameters, request and responses.
The just file has been updated to not overlap application and API tests

**Limits**
The examples in the swagger.json are generated from attributes in the C# applications, i.e API endpoints are decorated with example.  Swashbuckle doesn't support stream-octet as a request body example, thus the python API tests can't find an example for the API that expects an stream-octet. To over come this, the  python tests have hard coded the example which need an stream-octet body.

**Tested**
The changes were run locally and on the test pipeline [jason-ctools-486-test0-sdk-generation](https://concourse.finbourne.com/teams/client-tech/pipelines/jason-CTOOLS-486-test-sdk-generation?group=drive)

Lusid sdk generartion tested locally. Built using main, then rebuilt using this branch, no differences in the files generated were found.

See [Pipeline MR](https://gitlab.com/finbourne/client-technology/sdk-pipeline/-/merge_requests/36/edit) for test results when run in a test pipeline