### PR TITLE
CTOOLS-557: Added regex to regex map

### DIFF
--- a/generate/templates/api_test.mustache
+++ b/generate/templates/api_test.mustache
@@ -65,7 +65,8 @@ class {{#operations}}Test{{classname}}(unittest.IsolatedAsyncioTestCase):
                 # correctly generate the string from the regex
                 regex_map = {
                     r'^(?=.*[a-zA-Z])[\w][\w +-]{2,100}$': "official-portfolios-read-only",
-                    r'^[a-zA-Z0-9\\+/]*={0,3}$': "L=="
+                    r'^[a-zA-Z0-9\\+/]*={0,3}$': "L==",
+                    r'^[a-z\d]+((([.]{1}|[_]{1,2}|[-])+)([a-z\d]+))*:[a-z\d]+((([.]{1}|[_]{1,2}|[-])+)([a-z\d]+))*$': "namespace:identifier"
                 }
 
                 {{paramName}}: {{{dataType}}} = xegerObj.xeger(r"{{{vendorExtensions.x-regex}}}")


### PR DESCRIPTION
# Pull Request Checklist

# Description of the PR

Fixing Scheduler api tests. The api tests cannot generate the correct regex. 
The fix is to hard code a correct value for regex.

See passing pipeline https://concourse.finbourne.com/teams/client-tech/pipelines/CTOOLS-557-test-sdk-generation?group=scheduler