### PR TITLE
CTOOLS-564 remove old tests before overwriting with new

### DIFF
--- a/justfile
+++ b/justfile
@@ -177,7 +177,8 @@ generate-cicd TARGET_DIR FLAG="":
     # this prevents deleted content from hanging around indefinitely.
     rm -rf {{TARGET_DIR}}/sdk/${PACKAGE_NAME}
     rm -rf {{TARGET_DIR}}/sdk/docs
-    
+    rm -rf {{TARGET_DIR}}/sdk/test
+
     cp -R generate/.output/. {{TARGET_DIR}}
     echo "copied output to {{TARGET_DIR}}"
     ls {{TARGET_DIR}}


### PR DESCRIPTION
**About**
Old Tests were left orphaned, resulting in out of date tests being run.

**Change**
Altered just file to purge the V2-sdk-with-tests folder before copying the generated tests into this repo

**Tested**
See pipeline https://concourse.finbourne.com/teams/client-tech/pipelines/jason-ctools-564-test-sdk-generation?group=identity
Also generated the identity SDk and tested locally