### PR TITLE
CTOOLS-651: fixed up conlist(StrictStr)

### DIFF
--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -23,7 +23,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     {{^isString}}
     {{#hasItems}}
     {{#items.isEnumOrRef}}
-    {{name}}: {{^required}}Optional[{{/required}}conlist(StrictStr){{^required}}]{{/required}} = Field({{#required}}...{{/required}}{{^required}}None{{/required}},alias="{{baseName}}"{{#description}}, description="{{{description}}}"{{/description}})
+    {{name}}: {{^required}}Optional[{{/required}}conlist(str){{^required}}]{{/required}} = Field({{#required}}...{{/required}}{{^required}}None{{/required}},alias="{{baseName}}"{{#description}}, description="{{{description}}}"{{/description}})
     {{/items.isEnumOrRef}}
     {{^items.isEnumOrRef}}
     {{name}}: {{{vendorExtensions.x-py-typing}}}

--- a/generate/templates/model_generic.mustache
+++ b/generate/templates/model_generic.mustache
@@ -23,7 +23,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     {{^isString}}
     {{#hasItems}}
     {{#items.isEnumOrRef}}
-    {{name}}: {{^required}}Optional[{{/required}}conlist[Str]{{^required}}]{{/required}} = Field({{#required}}...{{/required}}{{^required}}None{{/required}},alias="{{baseName}}"{{#description}}, description="{{{description}}}"{{/description}})
+    {{name}}: {{^required}}Optional[{{/required}}conlist(StrictStr){{^required}}]{{/required}} = Field({{#required}}...{{/required}}{{^required}}None{{/required}},alias="{{baseName}}"{{#description}}, description="{{{description}}}"{{/description}})
     {{/items.isEnumOrRef}}
     {{^items.isEnumOrRef}}
     {{name}}: {{{vendorExtensions.x-py-typing}}}


### PR DESCRIPTION
**Problem**
Lusid SDK is using the conlist(Str), i.e. an array of strings. The templated code generation does not correctly generate the equivalent python code for this type.

Checking the swaggers & generated python SDKs it appears lusid is the only application in which this issue is exhibited

**Testing**
Branch tested on pipleline [jason-ctools-651-test-sdk-generation](https://concourse.finbourne.com/teams/client-tech/pipelines/jason-ctools-651-test-sdk-generation)

The LUSID automated tests do not provide coverage for this type. Tests are manual, run locally.

The issues was first manually reproduced, then retested with locally generated code as below;

<img width="707" alt="image" src="https://github.com/user-attachments/assets/a78611cb-ad9a-40bf-8d12-368fb2adc3d5" />


